### PR TITLE
Small Template Update to price list THs

### DIFF
--- a/src/modules/event-list/assets/templates/event-list.php
+++ b/src/modules/event-list/assets/templates/event-list.php
@@ -155,8 +155,8 @@ if ( isset( $css ) ) {
 					<input name="date_id" value="{{ id }}" type="hidden">
 					<table id="price-list-{{ id }}" class="bpt-event-list-prices">
 					<tr>
-						<th>Price Name</th>
-						<th>Price Value</th>
+						<th>Admission Level</th>
+						<th>Price</th>
 						<th>Quantity</th>
 					</tr>
 					{{ #prices }}


### PR DESCRIPTION
Updated the table headers of the price list section to match the terms used on Brown Paper Tickets (Price Name -> Admission Level, Price Value -> Price) 

Seeing "Price Name" & "Price Value" is such weird / redundant grammar (especially for a single price point event) that it looks like bug.