### PR TITLE
More Complete Calendar Widget Addresses

### DIFF
--- a/src/modules/calendar/assets/css/calendar-widget.css
+++ b/src/modules/calendar/assets/css/calendar-widget.css
@@ -1,7 +1,3 @@
-.bpt-calendar-widget, .bpt-calendar-shortcode {
-
-}
-
 /**
  * Calendar Controls
  */
@@ -12,14 +8,15 @@
 .bpt-calendar-widget-controls-month {
     width: 80%;
     padding: 5px;
-    font-size: bold;
+    font-size: 2em;
+    line-height: 1.5em;
+    font-weight: bold;
     text-align: center;
     display: inline-block;
-    box-sizing: -moz-border-box;
-    box-sizing: -webkit-border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     float: left;
-    line-height: 1.5em;
 }
 
 .bpt-calendar-shortcode .bpt-calendar-widget-controls-button,
@@ -27,12 +24,12 @@
     width: 10%;
     float: left;
     font-size: 2em;
+    line-height: 1.5em;
     cursor: pointer;
     display: inline-block;
-    box-sizing: -moz-border-box;
-    box-sizing: -webkit-border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
-
 }
 
 .bpt-calendar-shortcode .bpt-calendar-widget-controls-previous-button,
@@ -51,7 +48,6 @@
 .bpt-calendar-widget .clndr {
     width: 100%;
     float: left;
-    
 }
     .bpt-calendar-shortcode .bpt-calendar-widget-table,
     .bpt-calendar-widget .bpt-calendar-widget-table {
@@ -127,6 +123,6 @@
     margin-bottom: 10px;
 }
 
-    .bpt-calendar-widget-event-view-buy-tickets {
-        color: inherit;
-    }
+.bpt-calendar-widget-event-view-buy-tickets {
+    color: inherit;
+}

--- a/src/modules/calendar/calendar-api.php
+++ b/src/modules/calendar/calendar-api.php
@@ -49,6 +49,8 @@ class Api extends \BrownPaperTickets\Modules\ModuleApi {
 							'timeStart' => $date['timeStart'],
 							'timeEnd' => $date['timeEnd'],
 							'title' => $event['title'],
+							'address1' => $event['address1'],
+							'address2' => $event['address2'],
 							'city' => $event['city'],
 							'state' => $event['state'],
 							'zip' => $event['zip'],

--- a/src/modules/calendar/calendar-widget.php
+++ b/src/modules/calendar/calendar-widget.php
@@ -217,7 +217,9 @@ class Widget extends \WP_Widget {
 				<div class="bpt-calendar-widget-event-view-event" intro="slide" outro="fade">
 					<h2>{{{ unescapeHTML(title) }}}</h2>
 					<div class="bpt-calendar-widget-event-view-location">
-						{{ city }}, {{ state }}
+						 <div class="address1">{{ address1 }}</div>
+						 <div class="address2">{{ address2 }}</div>
+						 <div><span class="city">{{ city }}</span>, <span class="state">{{ state }}</span></div>
 					</div>
 					<div class="bpt-calendar-widget-event-view-date">
 						{{ formatDate( '<?php esc_attr_e( $date_format ); ?>', date ) }}


### PR DESCRIPTION
Currently, the calendar widget displays just the city & state for location info. 

For lists of events held at different addresses in the same city, this is not useful information. Having a complete address can only increase the usefulness, and custom CSS can be used to avoid displaying too much information.